### PR TITLE
fix: correct workflow paths for monorepo structure

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -21,20 +21,20 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: src/frontend/package-lock.json
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
         run: npm ci
-        working-directory: src/frontend
+        working-directory: frontend
 
       - name: Run lint
         run: npm run lint
-        working-directory: src/frontend
+        working-directory: frontend
 
       - name: Run tests
         run: npm test -- --run
-        working-directory: src/frontend
+        working-directory: frontend
 
       - name: Build application
         run: npm run build
-        working-directory: src/frontend
+        working-directory: frontend

--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,3 @@ Thumbs.db
 .idea/
 .vscode/
 *.code-workspace
-
-.github/


### PR DESCRIPTION
- Change cache-dependency-path from src/frontend/ to frontend/
- Update all working-directory paths to use frontend/ instead of src/frontend/
- Remove .github/ from .gitignore so workflows are tracked in git
- Resolve GitHub Actions npm cache error